### PR TITLE
Styling/comic collection css

### DIFF
--- a/src/components/ComicCollection/ComicCollection.css
+++ b/src/components/ComicCollection/ComicCollection.css
@@ -1,9 +1,14 @@
 .comicCollection {
   min-height: 100vh;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: center;
-  margin: 5%;
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  padding: 10px;
   gap: 20px
+}
+
+a {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/src/components/ComicCollection/ComicCollection.css
+++ b/src/components/ComicCollection/ComicCollection.css
@@ -1,8 +1,9 @@
 .comicCollection {
-  height: 70vh;
+  min-height: 100vh;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
-  margin: 1%;
+  margin: 5%;
+  gap: 20px
 }

--- a/src/components/ComicCollection/ComicCollection.css
+++ b/src/components/ComicCollection/ComicCollection.css
@@ -10,5 +10,5 @@
 a {
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: center
 }

--- a/src/components/NavBar/NavBar.css
+++ b/src/components/NavBar/NavBar.css
@@ -3,16 +3,18 @@
   justify-content: space-evenly;
   align-items: center;
   background: rgb(141, 88, 235);
-  height: 45vh;
+  height: 50vh;
   width: 100vw;
   margin: 0;
   font-weight: 900;
   font-size: 3vw;
   font-family: 'Bangers', cursive;
 }
+
 .my-collection-link,
 .add-comic-link {
   color: yellow;
+  font-size: 60px;
   text-shadow: -1px 1px 2px #000, 1px 1px 2px #000, 1px -1px 0 #000,
     -1px -1px 0 #000;
   transform: rotate(-18deg);
@@ -20,9 +22,12 @@
   transition-duration: 300ms;
 }
 
-.my-collection-link:hover,
-.add-comic-link:hover {
+.my-collection-link:hover {
   transform: scale(1.5) rotate(-10deg);
+}
+
+.add-comic-link:hover {
+  transform: scale(1.5) rotate(-25deg);
 }
 
 .my-collection,


### PR DESCRIPTION
#### What's this PR do?
This PR will merge some basic changes to `Comic Collection` CSS including:
- Changing display from flex to grid
- More space/gap for each comic card
- Each comic card image centered in its parent element
- View height changed to be 100 minimum height
#### Where should the reviewer start?
- Run command `git fetch`
- Run command `npm start`
#### How should this be manually tested?
- In browser navigate to comic collection to view changes
#### Screenshots
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/74210902/211177559-cefcd6f2-489e-4ac9-820d-db6d70c45b28.png">

