### PR TITLE
Styling/comic card css

### DIFF
--- a/cypress/e2e/comic_detail.cy.js
+++ b/cypress/e2e/comic_detail.cy.js
@@ -1,0 +1,44 @@
+describe('template spec', () => {
+   let imgSrc
+  beforeEach(() => {
+    imgSrc = "https://assets-global.website-files.com/5e9fa1c7e4ed1f5e242e2313/6193e5a113d2b7978adc2472_ZCi0CiIQ-Lmvvn6hUNV6j773Z_IQgMmuapFfCUUQXtUWDhqdL3ds_miY2q_Hw0dEX3ZhS6CdaCwzi3037ddvX_ea7XS4n1OGPEFHajAEtofPllmeqhcZPgkRkTTa5iulBXqR20aZ.png"
+    cy.visit('http://localhost:3000/')
+    cy.intercept('https://comic-can.herokuapp.com/api/v1/comicData', { fixture: 'getComicData.json'})
+    cy.get('.my-collection-link').click()
+    cy.get('.comicCard').first().click()
+  })
+
+  it('should have a cover image of the selected comic', () => {
+    cy.get('img').should('have.attr', 'src', imgSrc)
+  })
+
+  it('should show the title of the selected comic', () => {
+    cy.get('h2').contains('Amazing Fantasy')
+  })
+
+  it('should show the year of the selected comic', () => {
+    cy.get('p').first().contains('1962')
+  })
+
+  it('should show the issue number of the selected comic', () => {
+    cy.get('p').eq(1).contains('15')
+  })
+
+  it('should have a section for notes', () => {
+    cy.get('p').last().contains('Note')
+  })
+
+  it('should be verified if it has an uploaded cover image', () => {
+    expect(true).to.equal(true)
+  })
+
+  it('should have an "EDIT" button that bring up the edit form when clicked', () => {
+    cy.get('.edit').click()
+    cy.get('.form').should('be.visible')
+  })
+
+  it('should have a "BACK" button that returns to "My Collection" when clicked', () => {
+    cy.get('.back').click()
+    cy.url().should('eq', 'http://localhost:3000/comicCollection')
+  })
+})

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -3,13 +3,9 @@ import Home from "../Home/Home";
 import NavBar from "../NavBar/NavBar";
 import Form from "../Form/Form";
 import ComicCollection from "../ComicCollection/ComicCollection";
-import EditForm from "../EditForm/EditForm";
 import { Route, Routes } from "react-router";
 import React, { useState, useEffect } from "react";
-import { NavLink, Link } from "react-router-dom";
-
-//sample data in use
-//import sampleData from "../../sampleData.js/sampleData";
+import { Link } from "react-router-dom";
 import ComicDetail from "../ComicDetail/ComicDetail";
 
 function App() {

--- a/src/components/ComicCard/ComicCard.css
+++ b/src/components/ComicCard/ComicCard.css
@@ -1,4 +1,4 @@
-.comic-container{
+.card-container {
   position: relative;
 }
 
@@ -9,4 +9,25 @@
   display: block;
   transition: .5s ease;
   backface-visibility: hidden;
+}
+
+.overlay {
+  transition: .5s ease;
+  opacity: 1;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  -ms-transform: translate(-50%, -50%);
+  text-align: center;
+  color: white;
+  font-size: 30px;
+}
+
+.comic-image:hover {
+  opacity: 0.3;
+}
+
+.comic-image:hover .overlay{
+  opacity: 1;
 }

--- a/src/components/ComicCard/ComicCard.css
+++ b/src/components/ComicCard/ComicCard.css
@@ -1,4 +1,4 @@
 .comicCard {
   width: 15vw;
-  height: 50vh;
+  height: auto;
 }

--- a/src/components/ComicCard/ComicCard.css
+++ b/src/components/ComicCard/ComicCard.css
@@ -1,4 +1,12 @@
-.comicCard {
+.comic-container{
+  position: relative;
+}
+
+.comic-image {
   width: 15vw;
   height: auto;
+  opacity: 1;
+  display: block;
+  transition: .5s ease;
+  backface-visibility: hidden;
 }

--- a/src/components/ComicCard/ComicCard.css
+++ b/src/components/ComicCard/ComicCard.css
@@ -13,7 +13,7 @@
 
 .overlay {
   transition: .5s ease;
-  opacity: 1;
+  width: 100%;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -22,12 +22,13 @@
   text-align: center;
   color: white;
   font-size: 30px;
+  z-index: -1;
 }
 
 .comic-image:hover {
-  opacity: 0.3;
+  opacity: 0.2;
 }
 
 .comic-image:hover .overlay{
-  opacity: 1;
+  z-index: 1;
 }

--- a/src/components/ComicCard/ComicCard.js
+++ b/src/components/ComicCard/ComicCard.js
@@ -8,7 +8,7 @@ const ComicCard = ({ card }) => {
     <Link to={`/comicCollection/${card.id}`}>
       <div className="card-container">
         <img
-          className="comicCard"
+          className="comic-image"
           src={card.image_path}
           alt={`cover of ${card.title} ${card.year} ${card.issue}`}
         />

--- a/src/components/ComicCard/ComicCard.js
+++ b/src/components/ComicCard/ComicCard.js
@@ -13,9 +13,9 @@ const ComicCard = ({ card }) => {
           alt={`cover of ${card.title} ${card.year} ${card.issue}`}
         />
         <div className="overlay">
-          <p>{card.title}</p>
-          <p>Issue #{card.issue}</p>
-          <p>{card.year}</p>
+            <p>{card.title}</p>
+            <p>Issue #{card.issue}</p>
+            <p>{card.year}</p>
         </div>
       </div>
     </Link >

--- a/src/components/ComicCard/ComicCard.js
+++ b/src/components/ComicCard/ComicCard.js
@@ -1,19 +1,26 @@
-import React from "react";
-import "./ComicCard.css";
-import { Link } from "react-router-dom";
-import PropTypes from "prop-types";
+import React from "react"
+import "./ComicCard.css"
+import { Link } from "react-router-dom"
+import PropTypes from "prop-types"
 
 const ComicCard = ({ card }) => {
   return (
     <Link to={`/comicCollection/${card.id}`}>
-      <img
-        className="comicCard"
-        src={card.image_path}
-        alt={`cover of ${card.title} ${card.year} ${card.issue}`}
-      />
-    </Link>
-  );
-};
+      <div className="card-container">
+        <img
+          className="comicCard"
+          src={card.image_path}
+          alt={`cover of ${card.title} ${card.year} ${card.issue}`}
+        />
+        <div className="overlay">
+          <p>{card.title}</p>
+          <p>Issue #{card.issue}</p>
+          <p>{card.year}</p>
+        </div>
+      </div>
+    </Link >
+  )
+}
 
 ComicCard.propTypes = {
   card: PropTypes.shape({
@@ -23,6 +30,6 @@ ComicCard.propTypes = {
     year: PropTypes.string,
     issue: PropTypes.string,
   }).isRequired,
-};
+}
 
-export default ComicCard;
+export default ComicCard


### PR DESCRIPTION
#### What's this PR do?
This merge will:
- Finish comic card css
- Dynamically size comic card so each image appears consistent despite screen size
- Hover effect showing title, issue #, and year
#### Where should the reviewer start?
- Run `git fetch`
- Run `git checkout test/comic-detail-view`
#### How should this be manually tested?
- Run `npm start`
- Navigate to browser
- Navigate to `My Collection` page and notice changes described above
#### Screenshots
![image](https://user-images.githubusercontent.com/74210902/211222060-d8c9fb5d-51df-4cb7-bf00-8d8b11d8e422.png)

